### PR TITLE
Update hdata.py to prevent group naming collision

### DIFF
--- a/src/hdata.py
+++ b/src/hdata.py
@@ -223,7 +223,7 @@ class SheetInstance():
         if not subSheetAnchor:
             return
 
-        replContext: ReplicateContext = ReplicateContext(subPcbAnchor, subSheetAnchor, self._uuid)
+        replContext: ReplicateContext = ReplicateContext(subPcbAnchor, subSheetAnchor, self._uuidPath)
 
         # Clear Volatile items first
         clear_volatile_items(replContext.group)


### PR DESCRIPTION
Having nested schematics like this caused problems
```
Root
+- A
|  +- B
|  +- B1
|  +- B2
+- A1
|  +- B
|  +- B1
|  +- B2
```

Using the entire uuid path for the group name fixes this