### PR TITLE
Fix schematic parsing for non-ASCII files and warn on board load failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 fp-info-cache
+
+# macOS Finder metadata files
+.DS_Store

--- a/src/hdata.py
+++ b/src/hdata.py
@@ -70,6 +70,10 @@ class SheetFile():
             logger.warn(f"{str(self._boardPath)} Board file invalid")
             return
 
+        if board is None:
+            logger.warn(f"{str(self._boardPath)} Board file could not be loaded")
+            return
+
         if len(board.GetFootprints()) < 1:
             logger.warn(f"{str(self._boardPath)} Has no footprints")
             return

--- a/src/simpleSchParser.py
+++ b/src/simpleSchParser.py
@@ -42,7 +42,11 @@ def sch_parse_file(schematicFile: Path) -> dict:
     if not schematicFile.exists():
         raise FileNotFoundError("Path not found: " + str(schematicFile))
 
-    with open(schematicFile) as file:
-        parsedList = sexpdata.load(file)
+    try:
+        with open(schematicFile, encoding="utf-8") as file:
+            parsedList = sexpdata.load(file)
+    except UnicodeDecodeError:
+        with open(schematicFile, encoding="latin-1") as file:
+            parsedList = sexpdata.load(file)
     parsedList.pop(0)
     return sch_list_to_dict(parsedList)


### PR DESCRIPTION
This fixes a schematic parsing issue caused by file encoding mismatches by falling back from UTF-8 to Latin-1 when needed, preventing decode errors on schematics containing non-ASCII characters.
It also adds a clear warning when a board file exists but cannot be loaded.