### PR TITLE
Fix footprintInBounds dropping footprints with negative coordinates

### DIFF
--- a/src/placement.py
+++ b/src/placement.py
@@ -142,11 +142,17 @@ class ReplicateContext(PositionTransform, GroupManager):
 
 
 def footprintInBounds(footprint: pcbnew.FOOTPRINT):
-    fpPosition: pcbnew.VECTOR2I = footprint.GetPosition()
-    #If x or y is negative, a footprint is out of bounds
-    if fpPosition.x < 0 or fpPosition.y < 0:
-        return False
-    return True
+    # Footprints outside the source board's Edge.Cuts outline are treated
+    # as intentionally parked and excluded from being laid out in the parent
+    # project. The previous heuristic (x<0 or y<0 == out of bounds) silently
+    # dropped any footprint placed in the negative coordinate quadrants,
+    # which broke layouts whose origin is centered on the board.
+    # If the source board has no Edge.Cuts defined, include all footprints.
+    board = footprint.GetBoard()
+    bbox = board.GetBoardEdgesBoundingBox()
+    if bbox.GetWidth() <= 0 or bbox.GetHeight() <= 0:
+        return True
+    return bbox.Contains(footprint.GetPosition())
 
 def clear_volatile_items(group: pcbnew.PCB_GROUP):
     """Remove all Traces, Drawings, Zones in a group."""


### PR DESCRIPTION
Fixes #9.

## Summary

- Replace the `x<0 or y<0` quadrant check in `footprintInBounds` with a check against the source board's Edge.Cuts bounding box.
- Boards with no Edge.Cuts fall through to including all footprints, which matches the common sub-project workflow of defining the outline only in the parent.
- Preserves the documented "park footprints outside the board to leave them out of the root project" behaviour — it's now tied to the actual board outline rather than an arbitrary quadrant.

## Why

The old heuristic silently dropped every footprint whose position had a negative coordinate, regardless of whether it was actually inside the board outline. Any sub-project laid out around a centered origin (chip at (0, 0), components fanning into all four quadrants) would import with only the +/+ quadrant placed and grouped; everything else was left behind, ungrouped, at its original position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)