### PR TITLE
Kicad 10 compatibility & fix dimension positioning

### DIFF
--- a/src/hdata.py
+++ b/src/hdata.py
@@ -81,7 +81,7 @@ class SheetFile():
         # Default anchor as first footprint
         self._anchorRef = self.fpByRef[0]
 
-    def generate_subsheets(self, parentUUIDPath):
+    def generate_subsheets(self, parentUUIDPath, parentNamePath):
 
         sheetInstanceList = self._sheet.get("sheet", {})
 
@@ -95,7 +95,7 @@ class SheetFile():
 
             sheetInfo = sheetFileManager.get_file_by_path( sheetPath )
 
-            returnedList.append( SheetInstance(sheetInfo, instanceData, parentUUIDPath))
+            returnedList.append( SheetInstance(sheetInfo, instanceData, parentUUIDPath, parentNamePath))
 
         return returnedList
 
@@ -145,7 +145,13 @@ class SheetFile():
 
 
 class SheetInstance():
-    def __init__(self, sheetData: SheetFile, subSheetDict: dict, parentUUIDPath: str):
+    def __init__(
+        self,
+        sheetData: SheetFile,
+        subSheetDict: dict,
+        parentUUIDPath: str,
+        parentNamePath: str,
+    ):
         self._sheet = sheetData
         self._enabled = False
         # Exclude the last two parameters if we are the root sheet.
@@ -153,9 +159,10 @@ class SheetInstance():
         self._name = subSheetDict["property"]["Sheetname"]
         self._uuid = subSheetDict["uuid"]
         self._uuidPath = parentUUIDPath + "/" + self._uuid
+        self._namePath = parentNamePath + "/" + self._name
 
         if not sheetData.board:
-            self._subSheets = sheetData.generate_subsheets(self._uuidPath)
+            self._subSheets = sheetData.generate_subsheets(self._uuidPath, self._namePath)
 
     def ancestorHasValidBoard(self):
         if self._sheet.board:
@@ -223,7 +230,11 @@ class SheetInstance():
         if not subSheetAnchor:
             return
 
-        replContext: ReplicateContext = ReplicateContext(subPcbAnchor, subSheetAnchor, self._uuidPath)
+        replContext: ReplicateContext = ReplicateContext(
+            subPcbAnchor,
+            subSheetAnchor,
+            "subpcb_" + self._namePath,
+        )
 
         # Clear Volatile items first
         clear_volatile_items(replContext.group)
@@ -272,5 +283,6 @@ class RootInstance(SheetInstance):
         self._uuid = ""
         self._uuidPath = ""
         self._name = "Root"
+        self._namePath = self._name
 
-        self._subSheets = sheetFile.generate_subsheets(self._uuidPath)
+        self._subSheets = sheetFile.generate_subsheets(self._uuidPath, self._namePath)

--- a/src/placement.py
+++ b/src/placement.py
@@ -154,14 +154,14 @@ def clear_volatile_items(group: pcbnew.PCB_GROUP):
 
     itemTypesToRemove = (
         # Traces
-        pcbnew.PCB_TRACK, pcbnew.ZONE,
+        pcbnew.PCB_TRACK, pcbnew.PCB_VIA, pcbnew.PCB_ARC,
         # Drawings
-        pcbnew.PCB_SHAPE, pcbnew.PCB_TEXT,
+        pcbnew.PCB_SHAPE, pcbnew.PCB_TEXT, pcbnew.PCB_DIMENSION_BASE,
         # Zones
         pcbnew.ZONE
     )
 
-    for item in group.GetItems():
+    for item in list(group.GetItems()):
 
         # Gets all drawings in a group
         if isinstance(item.Cast(), itemTypesToRemove):
@@ -188,9 +188,7 @@ def copy_footprint_fields(
 
     # Remove Existing footprint fields
     for targetField in targetFootprint.GetFields():
-        sourceField = sourceFootprint.GetFieldByName(
-            targetField.GetName()
-        )
+        sourceField = get_footprint_field_by_name(sourceFootprint, targetField.GetName())
         if not sourceField:
             logger.info("Field not found by name")
             continue
@@ -201,6 +199,19 @@ def copy_footprint_fields(
         )
 
     targetFootprint.SetReference(originalReference)
+
+
+def get_footprint_field_by_name(
+    footprint: pcbnew.FOOTPRINT,
+    fieldName: str
+):
+    if hasattr(footprint, "GetFieldByName"):
+        return footprint.GetFieldByName(fieldName)
+
+    if hasattr(footprint, "HasField") and not footprint.HasField(fieldName):
+        return None
+
+    return footprint.GetField(fieldName)
 
 
 def copy_footprint_data(
@@ -234,14 +245,45 @@ def copy_drawings(context: ReplicateContext):
         newDrawing = sourceDrawing.Duplicate()
         context.targetBoard.Add(newDrawing)
 
-        # Set New Position
-        newDrawing.SetPosition(context.translate(sourceDrawing.GetPosition()))
-
-        # Drawings dont have .SetOrientation()
-        # instead do a relative rotation
-        newDrawing.Rotate(newDrawing.GetPosition(), context.orient(pcbnew.ANGLE_0))
+        transform_drawing(sourceDrawing, newDrawing, context)
 
         context.move(newDrawing)
+
+
+def transform_drawing(
+    sourceDrawing: pcbnew.BOARD_ITEM,
+    targetDrawing: pcbnew.BOARD_ITEM,
+    transform: PositionTransform,
+):
+    if isinstance(targetDrawing.Cast(), pcbnew.PCB_DIMENSION_BASE):
+        transform_dimension(sourceDrawing, targetDrawing, transform)
+        return
+
+    # Move preserves compound drawing geometry; SetPosition jumbles dimensions.
+    targetDrawing.Move(transform.translate(sourceDrawing.GetPosition()) - sourceDrawing.GetPosition())
+
+    # Drawings dont have .SetOrientation()
+    # instead do a relative rotation
+    targetDrawing.Rotate(targetDrawing.GetPosition(), transform.orient(pcbnew.ANGLE_0))
+
+
+def transform_dimension(
+    sourceDimension: pcbnew.PCB_DIMENSION_BASE,
+    targetDimension: pcbnew.PCB_DIMENSION_BASE,
+    transform: PositionTransform,
+):
+    targetDimension.SetStart(transform.translate(sourceDimension.GetStart()))
+    targetDimension.SetEnd(transform.translate(sourceDimension.GetEnd()))
+
+    if hasattr(sourceDimension, "GetCrossbarStart") and hasattr(targetDimension, "UpdateHeight"):
+        targetDimension.UpdateHeight(
+            transform.translate(sourceDimension.GetCrossbarStart()),
+            transform.translate(sourceDimension.GetCrossbarEnd()),
+        )
+
+    targetDimension.SetTextPos(transform.translate(sourceDimension.GetTextPos()))
+    targetDimension.SetTextAngle(transform.orient(sourceDimension.GetTextAngle()))
+
 
 def copy_traces(context: ReplicateContext, netMapping: dict):
     for sourceTrack in context.sourceBoard.Tracks():


### PR DESCRIPTION
* Use FOOTPRINT.GetField instead of .GetFieldByName, which no longer exists
* Track sheet path & name group after sheet path to avoid duplicating sheets
* Handle positioning of dimensions, which have a different transform system compared to other entities and end up jumbled otherwise